### PR TITLE
(WIP): Schema Evolution: add bucket + indexes to LiveNewsArticles

### DIFF
--- a/backend/models/LiveNewsArticles.js
+++ b/backend/models/LiveNewsArticles.js
@@ -2,8 +2,10 @@ const mongoose = require('mongoose');
 
 const LiveNewsArticleSchema = new mongoose.Schema({
     source: String,
+    // keep url indexed (fast lookups), but not unique
     url: { type: String, index: true, unique: true },
-    canonicalUrl: String,
+    // enfore uniqueness on canonicalized version
+    canonicalUrl: { type: String, index: true, unique: true},
     title: String,
     author: String,
     publishedAt: Date,
@@ -22,8 +24,19 @@ const LiveNewsArticleSchema = new mongoose.Schema({
     },
 
     tags: [String],
-    images: { lead: String}
+    images: { lead: String},
+
+    bucket: { type: String, enum: ['LIVE', 'ARCHIVE', 'COLD'], index: true, default: 'LIVE' },
+    sourceRank: { type: Number, default: 50 }, // tie-break
+    ingestedAt: { type: Date, default: Date.now }
 
 }, { collection: 'LiveNewsArticles', timestamps: true });
+
+// query-speed indexes
+LiveNewsArticleSchema.index({ bucket: 1, publishedAt: -1 });
+LiveNewsArticleSchema.index({ source: 1, publishedAt: -1 });
+
+// single text index combining fields
+LiveNewsArticleSchema.index({ title: 'text', 'raw.text': 'text' }); // for search
 
 module.exports = mongoose.model('LiveNewsArticle', LiveNewsArticleSchema);


### PR DESCRIPTION
### Schema Evolution:

- Modify `LIveNewsArticleSchema` to keep one primary collection in **LiveNewsArticles**
       - Add new fields (`bucket`, `sourceRank`, `ingestedAt`, etc.) to support lifecycle + search optimizations
- Replace old rollover system (moving docs between collections) with **bucket updater** inside same collection
- Map backend responses with current frontend shape